### PR TITLE
fix(routing): add required urlpattern-polyfill lib for lit router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lit-labs/router": "^0.1.4",
-        "lit": "^3.3.1"
+        "lit": "^3.3.1",
+        "urlpattern-polyfill": "^10.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -6570,6 +6571,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   ],
   "dependencies": {
     "@lit-labs/router": "^0.1.4",
-    "lit": "^3.3.1"
+    "lit": "^3.3.1",
+    "urlpattern-polyfill": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,2 @@
+import 'urlpattern-polyfill';
 import './app.js';


### PR DESCRIPTION
## Changes
- Add `urlpattern-polyfill` lib which is required for lit router
   - Fix router issues on mobile and safari