### PR TITLE
fix(workflows): prevent duplicate comment creation for check-changeset pr validation job

### DIFF
--- a/.github/workflows/pr-validation-checks.yml
+++ b/.github/workflows/pr-validation-checks.yml
@@ -40,3 +40,4 @@ jobs:
             ```
 
             This will guide you to create a small markdown file in the `.changeset/` folder describing your changes.
+          edit-mode: replace


### PR DESCRIPTION
## Change(s)

- Add `edit-mode` action input for `check-changeset` job

## What is the purpose of the change(s)?

- Prevents duplicate comment creation for check-changeset pr validation job
